### PR TITLE
Move post request helper outside of sdk class

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.1",
+    "@types/node": "^18.11.9",
     "@types/sinon": "^10.0.12",
     "@typescript-eslint/eslint-plugin": "^5.30.4",
     "@typescript-eslint/parser": "^5.30.4",

--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -33,12 +33,10 @@ export class ArcxAnalyticsSdk {
       'click',
       () => {
         requestAnimationFrame(() => {
-          /* eslint-disable @typescript-eslint/no-explicit-any */
           if (window.url !== location.href) {
             window.url = location.href
-            this.page({ url: (window as any).url })
+            this.page({ url: window.url })
           }
-          /* eslint-enable @typescript-eslint/no-explicit-any */
         })
       },
       true,
@@ -53,7 +51,6 @@ export class ArcxAnalyticsSdk {
   static async init(apiKey: string, config?: Partial<SdkConfig>): Promise<ArcxAnalyticsSdk> {
     const sdkConfig = { ...DEFAULT_SDK_CONFIG, ...config }
 
-    console.log('found in cache:', sdkConfig?.cacheIdentity && localStorage.getItem(IDENTITY_KEY))
     const identityId =
       (sdkConfig?.cacheIdentity && localStorage.getItem(IDENTITY_KEY)) ||
       (await postRequest(sdkConfig.url, apiKey, '/identify'))

--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -34,8 +34,8 @@ export class ArcxAnalyticsSdk {
       () => {
         requestAnimationFrame(() => {
           /* eslint-disable @typescript-eslint/no-explicit-any */
-          if ((window as any).url !== location.href) {
-            Object.defineProperty(window, 'url', location.href)
+          if (window.url !== location.href) {
+            window.url = location.href
             this.page({ url: (window as any).url })
           }
           /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -53,6 +53,7 @@ export class ArcxAnalyticsSdk {
   static async init(apiKey: string, config?: Partial<SdkConfig>): Promise<ArcxAnalyticsSdk> {
     const sdkConfig = { ...DEFAULT_SDK_CONFIG, ...config }
 
+    console.log('found in cache:', sdkConfig?.cacheIdentity && localStorage.getItem(IDENTITY_KEY))
     const identityId =
       (sdkConfig?.cacheIdentity && localStorage.getItem(IDENTITY_KEY)) ||
       (await postRequest(sdkConfig.url, apiKey, '/identify'))

--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -1,4 +1,3 @@
-import { cast, asString } from '@restless/sanitizers'
 import { Account, Attributes, ChainID, SdkConfig, TransactionHash } from './types'
 import {
   ATTRIBUTION_EVENT,
@@ -9,6 +8,7 @@ import {
   REFERRER_EVENT,
   TRANSACTION_EVENT,
 } from './constants'
+import { postRequest } from './helpers'
 
 export class ArcxAnalyticsSdk {
   private constructor(
@@ -29,30 +29,20 @@ export class ArcxAnalyticsSdk {
   /**********************/
 
   private trackPagesChanges() {
-    document.body.addEventListener('click', () => {
-      requestAnimationFrame(() => {
-        /* eslint-disable @typescript-eslint/no-explicit-any */
-        if ((window as any).url !== location.href) {
-          (window as any).url = location.href
-          this.page({ url: (window as any).url })
-        }
-        /* eslint-enable @typescript-eslint/no-explicit-any */
-      })
-    }, true)
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static async postAnalytics(arcxUrl: string, apiKey: string, path: string, data?: any): Promise<string> {
-    const response = await fetch(`${arcxUrl}${path}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json; charset=UTF-8',
-        'x-api-key': apiKey,
+    document.body.addEventListener(
+      'click',
+      () => {
+        requestAnimationFrame(() => {
+          /* eslint-disable @typescript-eslint/no-explicit-any */
+          if ((window as any).url !== location.href) {
+            Object.defineProperty(window, 'url', location.href)
+            this.page({ url: (window as any).url })
+          }
+          /* eslint-enable @typescript-eslint/no-explicit-any */
+        })
       },
-      body: JSON.stringify(data),
-    })
-    const body = await response.json()
-    return cast(body, asString)
+      true,
+    )
   }
 
   /********************/
@@ -63,10 +53,9 @@ export class ArcxAnalyticsSdk {
   static async init(apiKey: string, config?: Partial<SdkConfig>): Promise<ArcxAnalyticsSdk> {
     const sdkConfig = { ...DEFAULT_SDK_CONFIG, ...config }
 
-    const identityId = (
+    const identityId =
       (sdkConfig?.cacheIdentity && localStorage.getItem(IDENTITY_KEY)) ||
-      await this.postAnalytics(sdkConfig.url, apiKey, '/identify')
-    )
+      (await postRequest(sdkConfig.url, apiKey, '/identify'))
     sdkConfig?.cacheIdentity && localStorage.setItem(IDENTITY_KEY, identityId)
 
     return new ArcxAnalyticsSdk(apiKey, identityId, sdkConfig)
@@ -74,16 +63,11 @@ export class ArcxAnalyticsSdk {
 
   /** Generic event logging method. Allows arbitrary events to be logged. */
   event(event: string, attributes?: Attributes): Promise<string> {
-    return ArcxAnalyticsSdk.postAnalytics(
-      this.sdkConfig.url,
-      this.apiKey,
-      '/submit-event',
-      {
-        identityId: this.identityId,
-        event,
-        attributes: { ...attributes },
-      },
-    )
+    return postRequest(this.sdkConfig.url, this.apiKey, '/submit-event', {
+      identityId: this.identityId,
+      event,
+      attributes: { ...attributes },
+    })
   }
 
   /**
@@ -94,8 +78,11 @@ export class ArcxAnalyticsSdk {
    * from (e.g. `discord`, `twitter`) or a `campaignId` if you wish to track a
    * specific marketing campaign (e.g. `bankless-podcast-1`, `discord-15`).
    */
-  // eslinit-disable-next-line @typescript-eslint/no-explicit-any
-  attribute(attributes: { source?: string, campaignId?: string, [key: string]: any }): Promise<string> {
+  attribute(attributes: {
+    source?: string
+    campaignId?: string
+    [key: string]: unknown
+  }): Promise<string> {
     return this.event(ATTRIBUTION_EVENT, attributes)
   }
 
@@ -105,12 +92,16 @@ export class ArcxAnalyticsSdk {
   }
 
   /** Logs a wallet connect event. */
-  connectWallet(attributes: { chain: ChainID, account: Account }): Promise<string> {
+  connectWallet(attributes: { chain: ChainID; account: Account }): Promise<string> {
     return this.event(CONNECT_EVENT, attributes)
   }
 
   /** Logs an on-chain transaction made by an account. */
-  transaction(attributes: { chain: ChainID, transactionHash: TransactionHash, metadata?: Record<string, any> }) {
+  transaction(attributes: {
+    chain: ChainID
+    transactionHash: TransactionHash
+    metadata?: Record<string, unknown>
+  }) {
     return this.event(TRANSACTION_EVENT, {
       chain: attributes.chain,
       transaction_hash: attributes.transactionHash,

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './postRequest'

--- a/src/helpers/postRequest.ts
+++ b/src/helpers/postRequest.ts
@@ -1,0 +1,19 @@
+import { asString, cast } from '@restless/sanitizers'
+
+export async function postRequest(
+  base: string,
+  apiKey: string,
+  path: string,
+  data?: unknown,
+): Promise<string> {
+  const response = await fetch(`${base}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=UTF-8',
+      'x-api-key': apiKey,
+    },
+    body: JSON.stringify(data),
+  })
+  const body = await response.json()
+  return cast(body, asString)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+declare global {
+  interface Window {
+    url?: string
+  }
+}
+
 export type Attributes = Record<string, unknown>
 export type ChainID = string | number
 export type Account = string

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,11 @@
-export type Attributes = Record<string, any>
+export type Attributes = Record<string, unknown>
 export type ChainID = string | number
 export type Account = string
 export type TransactionHash = string
 
 export type SdkConfig = {
-  cacheIdentity: boolean,
-  trackPages: boolean,
-  trackReferrer: boolean,
-  url: string,
+  cacheIdentity: boolean
+  trackPages: boolean
+  trackReferrer: boolean
+  url: string
 }

--- a/test/ArcxAnalyticsSdk.test.ts
+++ b/test/ArcxAnalyticsSdk.test.ts
@@ -9,6 +9,7 @@ import { SdkConfig } from '../src/types'
 import sinon from 'sinon'
 import { expect } from 'chai'
 import { CONNECT_EVENT, PAGE_EVENT, TRANSACTION_EVENT, DEFAULT_SDK_CONFIG } from '../src/constants'
+import * as postRequestModule from '../src/helpers/postRequest'
 
 const PROD_URL_BACKEND = DEFAULT_SDK_CONFIG.url // Backwards compatability
 
@@ -26,25 +27,27 @@ const TEST_ATTRIBUTES = {
 const TEST_IDENTITY = 'ef9a0cb5f45edf8d0a9ce7f7'
 
 describe('(unit) ArcxAnalyticsSdk', () => {
-  let postAnalyticsStub: sinon.SinonStub
+  let postRequestStub: sinon.SinonStub
   let analyticsSdk: ArcxAnalyticsSdk
 
   beforeEach(async () => {
-    postAnalyticsStub = sinon.stub(ArcxAnalyticsSdk, 'postAnalytics').resolves(TEST_IDENTITY)
+    postRequestStub = sinon.stub(postRequestModule, 'postRequest').resolves(TEST_IDENTITY)
     analyticsSdk = await ArcxAnalyticsSdk.init(TEST_API_KEY, TEST_CONFIG)
-
-    postAnalyticsStub.resetHistory()
   })
+
+  beforeEach(() => postRequestStub.resetHistory())
+
+  afterEach(() => sinon.restore())
 
   it('#init', async () => {
     await ArcxAnalyticsSdk.init('', TEST_CONFIG)
-    expect(postAnalyticsStub.calledOnce).to.be.true
+    expect(postRequestStub.calledOnce).to.be.true
   })
 
   it('#event', async () => {
     await analyticsSdk.event('TEST_EVENT', TEST_ATTRIBUTES)
     expect(
-      postAnalyticsStub.calledOnceWith(
+      postRequestStub.calledOnceWith(
         PROD_URL_BACKEND,
         TEST_API_KEY,
         '/submit-event',
@@ -104,10 +107,6 @@ describe('(unit) ArcxAnalyticsSdk', () => {
     await analyticsSdk.event('TEST_EVENT', pageAttributes)
 
     expect(eventStub.calledOnceWith('TEST_EVENT', pageAttributes)).to.be.true
-  })
-
-  afterEach(() => {
-    sinon.restore()
   })
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,6 +211,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.16.tgz#0eb3cce1e37c79619943d2fd903919fc30850601"
   integrity sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg==
 
+"@types/node@^18.11.9":
+  version "18.11.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
+  integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
+
 "@types/sinon@^10.0.12":
   version "10.0.12"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.12.tgz#fb7009ea71f313a9da4644ba73b94e44d6b84f7f"


### PR DESCRIPTION
The `postAnalytics` function was set as static on the object but it shouldn't have been. This pr moves it to a `helpers/` folder.

Also updating the `Window` type to include an optional `url` parameter.
