### PR TITLE
Export esm and cjs correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
   "types": "dist/esm/src/index.d.ts",
   "module": "dist/esm/src/index.ts",
   "unpkg": "dist/index.umd.min.js",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/src/index.js",
+      "require": "./dist/cjs/src/index.js"
+    }
+  },
   "private": false,
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
closes #82

Tested with the vue import as described at https://github.com/arcxmoney/analytics-sdk/issues/82#issuecomment-1355471162