### PR TITLE
fix: avoid saving wrong identity id when api key is incorrect

### DIFF
--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -392,7 +392,7 @@ export class ArcxAnalyticsSdk {
   static async init(apiKey: string, config?: Partial<SdkConfig>): Promise<ArcxAnalyticsSdk> {
     const sdkConfig = { ...DEFAULT_SDK_CONFIG, ...config }
     /*
-      TODO: Remove this if statement aproximately in February.
+      TODO: Remove this if statement aproximately in February 2023 (https://github.com/arcxmoney/analytics-sdk/issues/96).
       Clean local storage in case if users with previous versions saved wrong indentity_id when ARCX_ANALYTIC_API_KEY was incorrect
     */
     if (

--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -395,10 +395,7 @@ export class ArcxAnalyticsSdk {
       TODO: Remove this if statement aproximately in February 2023 (https://github.com/arcxmoney/analytics-sdk/issues/96).
       Clean local storage in case if users with previous versions saved wrong indentity_id when ARCX_ANALYTIC_API_KEY was incorrect
     */
-    if (
-      window.localStorage.getItem(IDENTITY_KEY)?.length !== 64 &&
-      window.localStorage.getItem(IDENTITY_KEY)?.length !== 0
-    ) {
+    if (window.localStorage.getItem(IDENTITY_KEY)?.length !== 64) {
       window.localStorage.removeItem(IDENTITY_KEY)
     }
 

--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -391,6 +391,16 @@ export class ArcxAnalyticsSdk {
   /** Initialises the Analytics SDK with desired configuration. */
   static async init(apiKey: string, config?: Partial<SdkConfig>): Promise<ArcxAnalyticsSdk> {
     const sdkConfig = { ...DEFAULT_SDK_CONFIG, ...config }
+    /*
+      TODO: Remove this if statement aproximately in February.
+      Clean local storage in case if users with previous versions saved wrong indentity_id when ARCX_ANALYTIC_API_KEY was incorrect
+    */
+    if (
+      window.localStorage.getItem(IDENTITY_KEY)?.length !== 64 &&
+      window.localStorage.getItem(IDENTITY_KEY)?.length !== 0
+    ) {
+      window.localStorage.removeItem(IDENTITY_KEY)
+    }
 
     const identityId =
       (sdkConfig?.cacheIdentity && window.localStorage.getItem(IDENTITY_KEY)) ||

--- a/src/helpers/postRequest.ts
+++ b/src/helpers/postRequest.ts
@@ -15,5 +15,10 @@ export async function postRequest(
     body: JSON.stringify(data),
   })
   const body = await response.json()
-  return cast(body, asString)
+
+  if (response.ok) {
+    return cast(body, asString)
+  } else {
+    throw new Error(`Cannot fetch ${base}${path} with code ${response.status}`)
+  }
 }

--- a/test/ArcxAnalyticsSdk.test.ts
+++ b/test/ArcxAnalyticsSdk.test.ts
@@ -85,6 +85,16 @@ describe('(unit) ArcxAnalyticsSdk', () => {
       expect(postRequestStub.calledOnceWith(DEFAULT_SDK_CONFIG.url, '', '/identify')).to.be.true
     })
 
+    it('clean localstorage identity id if cached value is wrong ', async () => {
+      localStorage.setItem(IDENTITY_KEY, '0x123')
+      expect(localStorage.getItem(IDENTITY_KEY)).eq('0x123')
+
+      await ArcxAnalyticsSdk.init('', { ...ALL_FALSE_CONFIG, cacheIdentity: true })
+
+      expect(postRequestStub.calledOnceWith(DEFAULT_SDK_CONFIG.url, '', '/identify')).to.be.true
+      expect(localStorage.getItem(IDENTITY_KEY)).eq(TEST_IDENTITY)
+    })
+
     it('sets the current URL in the session storage when `trackPages` is true', async () => {
       expect(sessionStorage.getItem(CURRENT_URL_KEY)).to.be.null
       expect(window.location.href).to.eq(TEST_JSDOM_URL)

--- a/test/postRequest.test.ts
+++ b/test/postRequest.test.ts
@@ -6,6 +6,7 @@ import { TEST_API_KEY } from './constants'
 describe('(unit) postRequest', () => {
   it('calls fetch with the given arguments', async () => {
     global.fetch = sinon.stub().resolves({
+      ok: true,
       async json() {
         return 'test response'
       },


### PR DESCRIPTION
Closes https://github.com/arcxmoney/analytics-sdk/issues/91
