### PR TITLE
Buffer events until the socket connection is established

### DIFF
--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -422,14 +422,11 @@ export class ArcxAnalyticsSdk {
 
   /** Generic event logging method. Allows arbitrary events to be logged. */
   event(event: string, attributes?: Attributes) {
-    if (this.socket.connected) {
-      this.socket.emit('submit-event', {
-        event,
-        attributes,
-      })
-    } else {
-      this._report('error', 'ArcxAnalyticsSdk::event: socket is not connected')
-    }
+    // If the socket is not connected, the event will be buffered until reconnection and sent then
+    this.socket.emit('submit-event', {
+      event,
+      attributes,
+    })
   }
 
   /**


### PR DESCRIPTION
Currently there's a problem regarding automatic CONNECT and CLICK events:
- Load a page with the sdk installed where the wallet is already connected
- The CONNECT event is fired right away *while* the socket is connected. With the previous setup, an error would be thrown. However, if we just call `socket.emit(event, attributes)`, it is being buffered and sent when the connection is established so we don't lose any event.
