### PR TITLE
Add missing release plugins

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,4 +1,12 @@
 {
-    "branches": ['main'],
-    "plugins": ["semantic-release-export-data"]
+  "branches": [
+    "main"
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "semantic-release-export-data",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
+    "@semantic-release/git"
+  ]
 }


### PR DESCRIPTION
When I added the `semantic-release-export-data` semantic release plugin, I added the `plugins` directive, which overwrites all the default plugins, including the npm release plugin. This PR adds them back explicitly
