### PR TITLE
Remove git plugin

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -6,7 +6,6 @@
     "@semantic-release/commit-analyzer",
     "semantic-release-export-data",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/npm",
-    "@semantic-release/git"
+    "@semantic-release/npm"
   ]
 }


### PR DESCRIPTION
From the previous run, the git tag already gets published
