### PR TITLE
Add missing git release plugin

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -6,6 +6,7 @@
     "@semantic-release/commit-analyzer",
     "semantic-release-export-data",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/npm"
+    "@semantic-release/npm",
+    "@semantic-release/git"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@babel/plugin-transform-react-jsx": "^7.14.9",
     "@commitlint/cli": "^17.3.0",
     "@commitlint/config-conventional": "^17.3.0",
+    "@semantic-release/git": "^10.0.1",
     "@testing-library/react": "^13.4.0",
     "@types/chai": "^4.3.1",
     "@types/jsdom": "^20.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,6 +1677,20 @@
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-3.0.0.tgz#30a3b97bbb5844d695eb22f9d3aa40f6a92770c2"
   integrity sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==
 
+"@semantic-release/git@^10.0.1":
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/@semantic-release/git/-/git-10.0.1.tgz#c646e55d67fae623875bf3a06a634dd434904498"
+  integrity sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==
+  dependencies:
+    "@semantic-release/error" "^3.0.0"
+    aggregate-error "^3.0.0"
+    debug "^4.0.0"
+    dir-glob "^3.0.0"
+    execa "^5.0.0"
+    lodash "^4.17.4"
+    micromatch "^4.0.0"
+    p-reduce "^2.0.0"
+
 "@semantic-release/github@^8.0.0":
   version "8.0.6"
   resolved "https://registry.yarnpkg.com/@semantic-release/github/-/github-8.0.6.tgz#5235386d65a5d7d650dc10a6ebce908d213234f7"


### PR DESCRIPTION
I previously removed it, thinking that it would publish to git after publishing to NPM, but that wasn't the case because NPM assumed the position of default publish channel, resulting in the git release not being published.
