### PR TITLE
Set websocket as supported transport

### DIFF
--- a/src/helpers/createClientSocket.ts
+++ b/src/helpers/createClientSocket.ts
@@ -9,5 +9,6 @@ interface IQueryParams {
 export const createClientSocket = (url: string, queryParams: IQueryParams) => {
   return io(url, {
     query: queryParams,
+    transports: ['websocket'],
   })
 }


### PR DESCRIPTION
As pointed in [this issue](https://github.com/socketio/socket.io/issues/1739), we need to set `websocket` as supported transport to avoid too many requests on a high-load server
