### PR TITLE
Warn instead of report error when chain or account are undefined and disconnect is called

### DIFF
--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -178,7 +178,7 @@ export class ArcxAnalyticsSdk {
   private _handleAccountDisconnected() {
     if (!this.currentChainId || !this.currentConnectedAccount) {
       this._report(
-        'error',
+        'warning',
         'ArcxAnalyticsSdk::_handleAccountDisconnected: previousChainId or previousConnectedAccount is not set',
       )
       /**


### PR DESCRIPTION
There is an edge case where `_handleAccountDisconnected()` is called but no account nor `chainId` are set. This scenario is currently reported as an error, but it really is a warning, just to keep an eye on it.
