### PR TITLE
Log the provider in case it is not writable

### DIFF
--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -26,6 +26,7 @@ import {
 } from './constants'
 import { createClientSocket, getElementsFullInfo, postRequest } from './utils'
 import { Socket } from 'socket.io-client'
+import { inspect } from 'util'
 
 export class ArcxAnalyticsSdk {
   /* --------------------------- Private properties --------------------------- */
@@ -252,6 +253,7 @@ export class ArcxAnalyticsSdk {
       this._report(
         'warning',
         'ArcxAnalyticsSdk::_trackTransactions: provider.request is not writable',
+        { provider: inspect(this.provider) },
       )
       return false
     }
@@ -288,6 +290,7 @@ export class ArcxAnalyticsSdk {
       this._report(
         'warning',
         'ArcxAnalyticsSdk::_trackTransactions: provider.request is not writable',
+        { provider: inspect(this.provider) },
       )
       return false
     }
@@ -351,13 +354,18 @@ export class ArcxAnalyticsSdk {
   }
 
   /** Report error to the server in order to better understand edge cases which can appear */
-  _report(logLevel: 'error' | 'log' | 'warning', content: string): Promise<string> {
+  _report(
+    logLevel: 'error' | 'log' | 'warning',
+    msg: string,
+    additionalInfo?: Record<string, unknown>,
+  ): Promise<string> {
     return postRequest(this.sdkConfig.url, this.apiKey, '/log-sdk', {
       logLevel,
       data: {
-        msg: content,
+        msg,
         identityId: this.identityId,
         apiKey: this.apiKey,
+        ...(additionalInfo ? { additionalInfo } : {}),
       },
     })
   }


### PR DESCRIPTION
We want to know which providers are not writable. Currently we have rollbar errors but we can't determine what exactly the problem is. This change gives us more information.

The `provider` object is circular, so using `inspect` is better than using `JSON.stringify()`: https://stackoverflow.com/questions/11616630/how-can-i-print-a-circular-structure-in-a-json-like-format