### PR TITLE
Remove warning when disconnect is called a second time

### DIFF
--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -175,11 +175,7 @@ export class ArcxAnalyticsSdk {
   }
 
   private _handleAccountDisconnected() {
-    if (!this.currentChainId || !this.currentConnectedAccount) {
-      this._report(
-        'warning',
-        'ArcxAnalyticsSdk::_handleAccountDisconnected: previousChainId or previousConnectedAccount is not set',
-      )
+    if (!this.currentChainId && !this.currentConnectedAccount) {
       /**
        * It is possible that this function has already been called once and the cached values
        * have been cleared. This can happen in the following scenario:
@@ -187,7 +183,8 @@ export class ArcxAnalyticsSdk {
        * 2. Connect WalletConnect
        * 3. Disconnect
        *
-       * TODO: solve this case in https://github.com/arcxmoney/analytics-sdk/issues/124
+       * Another scenario is if the `disconnect` event is fired before or after the
+       * `accountsChanged` event
        */
       return
     }


### PR DESCRIPTION
Closes #124 

A disconnect event can be called twice, so ignore the second call:
![image](https://user-images.githubusercontent.com/5834876/224401256-c5c4d14a-9c83-4c54-8ce2-01fdfc9a42f9.png)
