### PR TITLE
Track `utm_content` in attribute call

### DIFF
--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -130,6 +130,7 @@ export class ArcxAnalyticsSdk {
         source: searchParams.get('utm_source'),
         medium: searchParams.get('utm_medium'),
         campaign: searchParams.get('utm_campaign'),
+        content: searchParams.get('utm_content'),
       }
     }
 
@@ -465,6 +466,7 @@ export class ArcxAnalyticsSdk {
     source?: string
     medium?: string
     campaign?: string
+    content?: string
     [key: string]: unknown
   }): void {
     return this.event(ATTRIBUTION_EVENT, attributes)
@@ -509,5 +511,6 @@ type FirstVisitPageType = {
     source: string | null
     medium: string | null
     campaign: string | null
+    content: string | null
   }
 }

--- a/test/ArcxAnalyticsSdk.test.ts
+++ b/test/ArcxAnalyticsSdk.test.ts
@@ -25,6 +25,7 @@ import {
   TEST_JSDOM_URL,
   TEST_REFERRER,
   TEST_UTM_CAMPAIGN,
+  TEST_UTM_CONTENT,
   TEST_UTM_MEDIUM,
   TEST_UTM_SOURCE,
 } from './constants'
@@ -103,6 +104,7 @@ describe('(unit) ArcxAnalyticsSdk', () => {
             source: TEST_UTM_SOURCE,
             medium: TEST_UTM_MEDIUM,
             campaign: TEST_UTM_CAMPAIGN,
+            content: TEST_UTM_CONTENT,
           },
         }),
       )
@@ -522,6 +524,7 @@ describe('(unit) ArcxAnalyticsSdk', () => {
             source: TEST_UTM_SOURCE,
             medium: TEST_UTM_MEDIUM,
             campaign: TEST_UTM_CAMPAIGN,
+            content: TEST_UTM_CONTENT,
           },
         })
 
@@ -541,6 +544,7 @@ describe('(unit) ArcxAnalyticsSdk', () => {
             source: TEST_UTM_SOURCE,
             medium: TEST_UTM_MEDIUM,
             campaign: TEST_UTM_CAMPAIGN,
+            content: TEST_UTM_CONTENT,
           },
         })
 

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,8 +1,9 @@
 export const TEST_UTM_SOURCE = 'facebook'
 export const TEST_UTM_CAMPAIGN = 'ad-camp'
 export const TEST_UTM_MEDIUM = 'cpc'
+export const TEST_UTM_CONTENT = 'ad-1'
 export const TEST_REFERRER = 'https://arcx.money/'
-export const TEST_JSDOM_URL = `https://example.com/?utm_source=${TEST_UTM_SOURCE}&utm_medium=${TEST_UTM_MEDIUM}&utm_campaign=${TEST_UTM_CAMPAIGN}`
+export const TEST_JSDOM_URL = `https://example.com/?utm_source=${TEST_UTM_SOURCE}&utm_medium=${TEST_UTM_MEDIUM}&utm_campaign=${TEST_UTM_CAMPAIGN}&utm_content=${TEST_UTM_CONTENT}`
 
 export const TEST_API_KEY = '01234'
 export const TEST_ACCOUNT = '0x1234567890123456789012345678901234567890'


### PR DESCRIPTION
Even though `utm_content` was present in the url, it was not passed in the `attribute()` call. This pr fixes this.
