### PR TITLE
Add `signedMessage()` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,25 @@ arcx.transaction({
 
 > 🔥 Hurray! You’ve completed the bare-bone installation of the ARCx analytics SDK. The following steps beyond this are optional but can given greater resolution and insights if implemented.
 
-#### 4. Events & Attribution (optional)
+#### 4. Signatures
+
+Signing events can occur when a user signs a message through their wallet. The ARCx analytics SDK allows tracking these events through the signedMessage function. Leveraging this function enables the capturing of intricate details surrounding signed messages, enhancing the granularity of analytics derived from user interactions. Here’s how to use the function:
+
+```typescript
+arcx.signedMessage({
+  message,          // required(string) - The message that was signed
+  signatureHash,    // optional(string) - The hash of the signature
+  account,          // optional(string) - The account that signed the message. If not passed, the previously recorded account by the SDK will be utilized
+})
+```
+
+**Parameters:**
+
+- `message`: (**Required**, string) - The message that was signed. This parameter cannot be empty; attempting to pass an empty string will throw an error, ensuring that meaningful data is always captured.
+- `signatureHash`: (Optional, string) - The hash associated with the signature. While not compulsory, including this detail can help us confirm whether the signature is valid.
+- `account`: (Optional, string) - The account involved in signing the message. In instances where it is not provided, the SDK will refer to the most recently recorded account either from the last `connectWallet()` call or discovered automatically on Metamask given the `trackWalletConnections` option is turned on.
+
+#### 5. Events & Attribution (optional)
 
 ---
 

--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -488,6 +488,8 @@ export class ArcxAnalyticsSdk {
    *
    * @param chainId The new chain ID the wallet connected to.
    * Either in hexadeciaml or decimal format.
+   * @param account (optional) The connected account.
+   * If not passed, the previously recorded account by the SDK will be used.
    */
   chainChanged({ chainId, account }: { chainId: ChainID; account?: string }) {
     if (!chainId || Number(chainId) === 0) {
@@ -518,6 +520,39 @@ export class ArcxAnalyticsSdk {
       chain: attributes.chain,
       transaction_hash: attributes.transactionHash,
       metadata: attributes.metadata || {},
+    })
+  }
+
+  /**
+   * Logs a signing event.
+   * @param message Missage that was signed
+   * @param signatureHash (optional) The signature hash
+   * @param account (optional) The account that signed the message. If not passed, the previously
+   * recorded account by the SDK will be used.
+   */
+  signedMessage({
+    message,
+    signatureHash,
+    account,
+  }: {
+    message: string
+    signatureHash?: string
+    account?: string
+  }) {
+    if (!message) {
+      throw new Error('ArcxAnalyticsSdk::signedMessage: message cannot be empty')
+    }
+
+    if (!account && !this.currentConnectedAccount) {
+      throw new Error(
+        'ArcxAnalyticsSdk::signedMessage: account cannot be empty and was not previously recorded',
+      )
+    }
+
+    return this.event(SIGNING_EVENT, {
+      message,
+      ...(signatureHash && { signatureHash: signatureHash }),
+      account: account || this.currentConnectedAccount,
     })
   }
 

--- a/test/ArcxAnalyticsSdk.test.ts
+++ b/test/ArcxAnalyticsSdk.test.ts
@@ -385,6 +385,77 @@ describe('(unit) ArcxAnalyticsSdk', () => {
       })
     })
 
+    describe('#signedMessage', () => {
+      it('throws if message is empty', async () => {
+        try {
+          await sdk.signedMessage({
+            message: '',
+          })
+        } catch (err: any) {
+          expect(err.message).to.eq('ArcxAnalyticsSdk::signedMessage: message cannot be empty')
+          return
+        }
+        fail('should throw')
+      })
+
+      it('throws if account is undefined and currentConnectedAccount is undefined', async () => {
+        expect(sdk.currentConnectedAccount).to.be.undefined
+
+        try {
+          await sdk.signedMessage({
+            message: 'hello',
+          })
+        } catch (err: any) {
+          expect(err.message).to.eq(
+            'ArcxAnalyticsSdk::signedMessage: account cannot be empty and was not previously recorded',
+          )
+          return
+        }
+        fail('should throw')
+      })
+
+      it('submits a signing event with the currentConnectedAccount if account is undefined', async () => {
+        const eventStub = sinon.stub(sdk, 'event')
+        sdk.currentConnectedAccount = TEST_ACCOUNT
+        await sdk.signedMessage({
+          message: 'hello',
+        })
+        expect(eventStub).calledOnceWithExactly(SIGNING_EVENT, {
+          account: TEST_ACCOUNT,
+          message: 'hello',
+        })
+      })
+
+      it('submits a signing event with the given account if account is defined', async () => {
+        const eventStub = sinon.stub(sdk, 'event')
+        const account = '0x123'
+        await sdk.signedMessage({
+          account,
+          message: 'hello',
+        })
+        expect(eventStub).calledOnceWithExactly(SIGNING_EVENT, {
+          account,
+          message: 'hello',
+        })
+      })
+
+      it('submits a signing event with the given hash if hash is defined', async () => {
+        const eventStub = sinon.stub(sdk, 'event')
+        const account = '0x123'
+        const hash = '0x123456789'
+        await sdk.signedMessage({
+          account,
+          signatureHash: hash,
+          message: 'hello',
+        })
+        expect(eventStub).calledOnceWithExactly(SIGNING_EVENT, {
+          account,
+          signatureHash: hash,
+          message: 'hello',
+        })
+      })
+    })
+
     describe('#referrer', () => {
       it('calls event() with the given attributes', async () => {
         const eventStub = sinon.stub(sdk, 'event')


### PR DESCRIPTION
Closes #145

Writing this PR made me realise that we're inconsistent with the naming style of our public functions. Will create a new PR to make them uniform.
