### PR TITLE
Add disconnection() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,29 @@ await analytics.transaction({
 })
 ```
 
+### `signature`
+
+Logs a signing event when a message is signed.
+
+**Parameters:**
+
+- `options` **(object)**
+- `message` **(string)** - The message that was signed. This parameter is required and cannot be empty.
+  - `signatureHash` **(string, optional)** - The hash of the signature. If not provided, it will be excluded from the event attributes.
+- `account` **(string, optional)** - The account that signed the message. If not provided, the SDK will use the previously recorded account.
+
+**Example:**
+
+```typescript
+await analytics.signature({
+  message: 'Hello, world!',
+  signatureHash: '0x123abc',
+  account: '0x123',
+})
+```
+
+
+
 ### `attribute`
 
 Attaches metadata about a session indicating the origination of the traffic.

--- a/README.md
+++ b/README.md
@@ -280,6 +280,25 @@ await analytics.wallet({
 })
 ```
 
+### `disconnection`
+
+Logs a wallet disconnection event. This function will clear the cached known chain ID and account.
+
+**Parameters:**
+
+- `attributes` **(object, optional)**
+  - `account` **(string, optional)** - The disconnected account address. If not provided, the function will use the previously recorded account address.
+  - `chainId` **(string | number, optional)** - The chain ID from which the wallet was disconnected. If not passed, the function will use the previously recorded chain ID.
+
+**Example:**
+
+```typescript
+await analytics.disconnection({
+  account: '0x123',
+  chainId: 1,
+})
+```
+
 ### `chain`
 
 Logs when there is a change in the blockchain the user’s wallet is connected to. This function is instrumental in tracking user behavior associated with different chains, facilitating a richer analysis in your ARCx analytics setup.

--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -189,7 +189,7 @@ export class ArcxAnalyticsSdk {
        * 3. Disconnect
        *
        * Another scenario is if the `disconnect` event is fired before or after the
-       * `accountsChanged` event
+       * `accountsChanged` event or if `disconnection()` was called before this function.
        */
       return
     }

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -3,8 +3,6 @@ import { EIP1193Provider } from './web3'
 
 export type Attributes = Record<string, unknown>
 export type ChainID = string | number
-export type Account = string
-export type TransactionHash = string
 
 export type SdkConfig = {
   /* ---------------------------- Internal settings --------------------------- */


### PR DESCRIPTION
Closes #149
Depends on https://github.com/arcxmoney/analytics-sdk/pull/153

Not disabling automatic disconnection because it shouldn't do any harm. If the user fires `disconnect()` and we've already done it automatically, nothing will happen.
