### PR TITLE
Add `chainId` attribute to `TRANSACTION_TRIGGERED`

### DIFF
--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -239,6 +239,7 @@ export class ArcxAnalyticsSdk {
 
         this._event(Event.TRANSACTION_TRIGGERED, {
           ...transactionParams,
+          chainId: this.currentChainId,
           nonce,
         })
       }

--- a/test/ArcxAnalyticsSdk.test.ts
+++ b/test/ArcxAnalyticsSdk.test.ts
@@ -928,6 +928,7 @@ describe('(unit) ArcxAnalyticsSdk', () => {
           trackTransactions: true,
           initialProvider: window.web3.currentProvider,
         })
+        sdk.currentChainId = TEST_CHAIN_ID
         const eventStub = sinon.stub(sdk, '_event' as any)
 
         await window.web3.currentProvider!.request({
@@ -936,6 +937,7 @@ describe('(unit) ArcxAnalyticsSdk', () => {
         })
         expect(eventStub).calledWithExactly(Event.TRANSACTION_TRIGGERED, {
           ...transactionParams,
+          chainId: TEST_CHAIN_ID,
           nonce,
         })
       })


### PR DESCRIPTION
I realized we had it but didn't report it which is a value that is missing given the new EventV2 schema.
