### PR TITLE
Disable automatic event tracking for the npm package and add library usage header

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Installation Guide
 
-## Option 1 - via script tag (preferred)
+## Option 1 - via script tag (Metamask only)
 
 ---
 
@@ -17,7 +17,7 @@ This is the simplest option to get started with ARCx Analytics, all you need to 
   const config = {} // Add any configuration parameters you'd like here
   script.src = '<https://unpkg.com/@arcxmoney/analytics>'
   script.onload = function () {
-    ArcxAnalyticsSdk.init(apiKey, config).then(function (sdk) {
+    ArcxAnalyticsSdk.init(apiKey, config, 'script-tag').then(function (sdk) {
       window.arcx = sdk
     })
   }
@@ -80,7 +80,7 @@ Once you’ve done that, you’ll need to initialise the SDK and keep an instanc
 ```jsx
 import { ArcxAnalyticsSdk } from '@arcxmoney/analytics'
 
-let arcx = await ArcxAnalyticsSdk.init(API_KEY, {
+const sdk = await ArcxAnalyticsSdk.init(API_KEY, {
   // list any features you'd like to disable here
   trackPages: false,
   trackWalletConnections: false,
@@ -89,6 +89,8 @@ let arcx = await ArcxAnalyticsSdk.init(API_KEY, {
 
 ### Manual event tracking
 
+**Note:** the `sdk` instance in this section comes from the react hook (`sdk = useArcxAnalytics()`, option 2) or the manual instantiation as showin in option 3.
+
 #### 1. Wallet Connects
 
 ---
@@ -96,7 +98,7 @@ let arcx = await ArcxAnalyticsSdk.init(API_KEY, {
 A critical part of the ARCx analytics product is associating off-chain behaviour with on-chain wallet activity. In order to do this, we need to be able to link your wallet to the currently active session and the chain that the user is connected to. The chain field should contain the numeric chain ID passed as a string.
 
 ```jsx
-arcx.wallet({ account: '0x1234', chainId: '1' })
+sdk.wallet({ account: '0x1234', chainId: '1' })
 ```
 
 #### 2. Chain changes
@@ -106,7 +108,7 @@ arcx.wallet({ account: '0x1234', chainId: '1' })
 To effectively track and log the changes in the blockchain that the wallet is connected to, the ARCx analytics SDK offers a `chain` function. Utilize this function to note the alterations in the chain ID, fostering more substantial and dynamic analytics. Here is a breakdown of how you can employ this function in your SDK:
 
 ```typescript
-arcx.chain({ chainId: 1, account: '0x1234' })
+sdk.chain({ chainId: 1, account: '0x1234' })
 ```
 
 **Parameters:**
@@ -121,7 +123,7 @@ arcx.chain({ chainId: 1, account: '0x1234' })
 The final piece for a bare-bone installation of ARCx analytics is registering transactions that occur on-chain. In addition to passing the transaction hash, we need the ID of the chain the transaction is occurring on and optionally, any attributes you’d like to pass to further segment the event.
 
 ```jsx
-arcx.transaction({
+sdk.transaction({
   chain, // required(string) - chain ID that the transaction is taking place on
   transactionHash, // required(string) - hash of the transaction
   metadata, // optional(object) - additional information about the transaction
@@ -135,7 +137,7 @@ arcx.transaction({
 Signing events can occur when a user signs a message through their wallet. The ARCx analytics SDK allows tracking these events through the signedMessage function. Leveraging this function enables the capturing of intricate details surrounding signed messages, enhancing the granularity of analytics derived from user interactions. Here’s how to use the function:
 
 ```typescript
-arcx.signature({
+sdk.signature({
   message, // required(string) - The message that was signed
   signatureHash, // optional(string) - The hash of the signature
   account, // optional(string) - The account that signed the message. If not passed, the previously recorded account by the SDK will be utilized
@@ -148,26 +150,17 @@ arcx.signature({
 - `signatureHash`: (Optional, string) - The hash associated with the signature. While not compulsory, including this detail can help us confirm whether the signature is valid.
 - `account`: (Optional, string) - The account involved in signing the message. In instances where it is not provided, the SDK will refer to the most recently recorded account either from the last `connectWallet()` call or discovered automatically on Metamask given the `trackWalletConnections` option is turned on.
 
-#### 5. Events & Attribution (optional)
+#### 5. Events (optional)
 
 ---
 
 Tracking key events inside your app allows the product to provide detailed information such as what percentage of whales convert through your product funnel relative to new users. The more event data we have, the more insights we can provide to help improve your product.
 
 ```jsx
-arcx.event(
+sdk.event(
   eventName, // required(string) - the name of the event (eg. "clicked-tab")
   attributes, // optional(object) - additional information about the event
 )
-```
-
-In addition to events, tracking attribution allows you to understand which marketing campaigns are successful through wallet tagging.
-
-```jsx
-arcx.attribute({
-  source, // optional(string) - the origin of the web traffic (eg. discord, twitter etc)
-  campaignId, // optional(string) - a specific identifier of the campaign (eg. bankless-5)
-})
 ```
 
 > ✅ That’s all there is to it. Leave all the magic on-chain wizardry to us from beyond here.
@@ -178,18 +171,17 @@ Regardless of which installation method you choose, you can disable any automati
 
 The configuration options are:
 
-| Config key               | Type            | Description                                                                                            | Default           |
-| ------------------------ | --------------- | ------------------------------------------------------------------------------------------------------ | ----------------- |
-| `cacheIdentity`          | boolean         | Caches the identity of users in the browser's local storage to capture cross-session behaviours        | `true`            |
-| `initialProvider`        | EIP1193Provider | The provider to use for the web3 tracking events                                                       | `window.ethereum` |
-| `trackReferrer`          | boolean         | Whether or not to emit an initial `REFERRER` event containing the referrer attribute                   | `true`            |
-| `trackPages`             | boolean         | Tracks whenever there is a URL change during the session and logs it automatically.                    | `true`            |
-| `trackUTM`               | boolean         | Automatically reports the UTM tags (`utm_campaign, utm_medium, utm_source`) of the first page visit    | `true`            |
-| `trackWalletConnections` | boolean         | Automatically track wallet connections on the provider passed to `initialProvider` or `setProvider`.   | `true`            |
-| `trackChainChanges`      | boolean         | Automatically track chain ID changes on the provider passed to `initialProvider` or `setProvider`.     | `true`            |
-| `trackTransactions`      | boolean         | Automatically track transaction requests on the provider passed to `initialProvider` or `setProvider`. | `true`            |
-| `trackSigning`           | boolean         | Automatically track signing requests on the provider passed to `initialProvider` or `setProvider`.     | `true`            |
-| `trackClicks`            | boolean         | Automatically track click events                                                                       | `true`            |
+| Config key               | Type    | Description                                                                                         | Default |
+| ------------------------ | ------- | --------------------------------------------------------------------------------------------------- | ------- |
+| `cacheIdentity`          | boolean | Caches the identity of users in the browser's local storage to capture cross-session behaviours     | `true`  |
+| `trackReferrer`          | boolean | Whether or not to emit an initial `REFERRER` event containing the referrer attribute                | `true`  |
+| `trackPages`             | boolean | Tracks whenever there is a URL change during the session and logs it automatically.                 | `true`  |
+| `trackUTM`               | boolean | Automatically reports the UTM tags (`utm_campaign, utm_medium, utm_source`) of the first page visit | `true`  |
+| `trackWalletConnections` | boolean | Automatically track wallet connections (Metamask only)                                              | `true`  |
+| `trackChainChanges`      | boolean | Automatically track chain ID changes (Metamask only)                                                | `true`  |
+| `trackTransactions`      | boolean | Automatically track transaction requests (Metamask only)                                            | `true`  |
+| `trackSigning`           | boolean | Automatically track signing requests (Metamask only)                                                | `true`  |
+| `trackClicks`            | boolean | Automatically track click events                                                                    | `true`  |
 
 # API
 
@@ -219,7 +211,9 @@ await analytics = await ArcxAnalyticsSdk.init(
 )
 ```
 
-### `setProvider`
+### `setProvider` (deprecated)
+
+> Deprecated. Use the manual event tracking instead.
 
 Sets the [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) to use. If automatic EVM events tracking is enabled, the registered listeners will be removed from the old provider and added to the new one.
 
@@ -357,33 +351,11 @@ await analytics.signature({
 })
 ```
 
-### `attribute`
-
-Attaches metadata about a session indicating the origination of the traffic.
-Used for more advanced analytics.
-
-**Parameters:**
-
-- `attributes` **(object)**
-  - `source` **optional(string)** - the `source` that the traffic originated from (e.g. `discord`, `twitter`)
-  - `medium` **optional(string)** - the `medium`, defining the medium your visitors arrived at your site
-  * (e.g. `social`, `email`)
-  - `campaign` **optional(string)** - the `campaign` if you wish to track a specific marketing campaign (e.g. `bankless-podcast-1`, `discord-15`)
-
-**Example:**
-
-```js
-await analytics.attribute({
-  source: 'discord',
-  campaign: 'ama--2022-10-10',
-})
-```
-
 # Important Note
 
 We do not support automatic wallet activity tracking with wallets other than Metamask.
 
-To fix this, you must pass the newly connected provider to the `sdk.setProvider(newProvider)` instance. Doing so will tell the SDK to watch that provider and fire any wallet connections/transactions/signature requests that wallet will be doing on your dApp! ✅
+If your dApp supports multiple wallets, you must use the manual event tracking method (installation Option 2).
 
 # Development notes
 

--- a/README.md
+++ b/README.md
@@ -211,16 +211,6 @@ await analytics = await ArcxAnalyticsSdk.init(
 )
 ```
 
-### `setProvider` (deprecated)
-
-> Deprecated. Use the manual event tracking instead.
-
-Sets the [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) to use. If automatic EVM events tracking is enabled, the registered listeners will be removed from the old provider and added to the new one.
-
-**Parameters:**
-
-- `provider` **(EIP1193Provider)** - the provider to use
-
 ### `event`
 
 A generic, catch-all `event` log. Use this method when no existing methods

--- a/example/cra-script-tag/public/index.html
+++ b/example/cra-script-tag/public/index.html
@@ -26,7 +26,7 @@
         config = {
           url: '%REACT_APP_ARCX_API_URL%',
         }
-        ArcxAnalyticsSdk.init(apiKey, config).then(function (sdk) {
+        ArcxAnalyticsSdk.init(apiKey, config, 'script-tag').then(function (sdk) {
           window.arcx = sdk
         })
       }

--- a/example/cra-script-tag/src/Web3Buttons.tsx
+++ b/example/cra-script-tag/src/Web3Buttons.tsx
@@ -9,9 +9,7 @@ export const Web3Buttons = () => {
   const [connectedWallet, setConnectedWallet] = useState<'metamask' | 'walletConnect' | undefined>()
 
   useEffect(() => {
-    if (sdk && provider) {
-      sdk.setProvider(provider.provider as any)
-    } else if (sdk && sdk.provider && !provider) {
+    if (sdk && sdk.provider && !provider) {
       // provider disconnected from external source (e.g. user clicked disconnect in wallet connect)
       setConnectedWallet(undefined)
     }

--- a/example/cra-script-tag/src/types/types.ts
+++ b/example/cra-script-tag/src/types/types.ts
@@ -23,6 +23,5 @@ export interface ArcxAnalyticsSdk {
     metadata?: Record<string, unknown>
   }) => Promise<string>
   referrer: (referrer?: string) => Promise<string>
-  setProvider: (provider: EIP1193Provider | undefined) => void
   _report: (logLevel: 'error' | 'log' | 'warning', content: string) => Promise<string>
 }

--- a/src/ArcxAnalyticsProvider.tsx
+++ b/src/ArcxAnalyticsProvider.tsx
@@ -15,7 +15,17 @@ export const ArcxAnalyticsProvider = ({ apiKey, config, children }: ArcxAnalytic
     if (initializedStartedRef.current) return
     initializedStartedRef.current = true
 
-    ArcxAnalyticsSdk.init(apiKey, config).then((sdk) => setSdk(sdk))
+    ArcxAnalyticsSdk.init(
+      apiKey,
+      {
+        ...config,
+        trackWalletConnections: false,
+        trackChainChanges: false,
+        trackTransactions: false,
+        trackSigning: false,
+      },
+      'npm-package',
+    ).then((sdk) => setSdk(sdk))
   }, [apiKey])
 
   return <ArcxAnalyticsContext.Provider value={sdk}>{children}</ArcxAnalyticsContext.Provider>

--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -37,9 +37,9 @@ export class ArcxAnalyticsSdk {
     public readonly identityId: string,
     private readonly sdkConfig: SdkConfig,
     private socket: Socket,
-    private _libraryUsage?: LibraryUsageType,
+    private _libraryType?: LibraryUsageType,
   ) {
-    if (_libraryUsage !== 'npm-package') {
+    if (_libraryType !== 'npm-package') {
       const provider = window?.ethereum || window.web3?.currentProvider
       if (provider) {
         this._trackProvider(provider)
@@ -373,7 +373,7 @@ export class ArcxAnalyticsSdk {
           url: window.location.href,
         },
       },
-      this._libraryUsage ? { [LIBRARY_USAGE_HEADER]: this._libraryUsage } : undefined,
+      this._libraryType ? { [LIBRARY_USAGE_HEADER]: this._libraryType } : undefined,
     )
   }
 
@@ -437,32 +437,27 @@ export class ArcxAnalyticsSdk {
   static async init(
     apiKey: string,
     config?: Partial<SdkConfig>,
-    libraryUsage?: LibraryUsageType,
+    libraryType?: LibraryUsageType,
   ): Promise<ArcxAnalyticsSdk> {
     const sdkConfig = { ...DEFAULT_SDK_CONFIG, ...config }
 
-    const identityId = await ArcxAnalyticsSdk._getIdentitityId(sdkConfig, apiKey, libraryUsage)
+    const identityId = await ArcxAnalyticsSdk._getIdentitityId(sdkConfig, apiKey, libraryType)
     const sessionId = ArcxAnalyticsSdk._getSessionId(identityId)
 
-    const extraHeaders =
-      libraryUsage !== undefined ? { [LIBRARY_USAGE_HEADER]: libraryUsage } : undefined
-    const websocket = createClientSocket(
-      sdkConfig.url,
-      {
-        apiKey,
-        identityId,
-        sdkVersion: SDK_VERSION,
-        screenHeight: screen.height,
-        screenWidth: screen.width,
-        viewportHeight: window.innerHeight,
-        viewportWidth: window.innerWidth,
-        url: window.location.href,
-        sessionStorageId: sessionId,
-      },
-      extraHeaders,
-    )
+    const websocket = createClientSocket(sdkConfig.url, {
+      apiKey,
+      identityId,
+      sdkVersion: SDK_VERSION,
+      screenHeight: screen.height,
+      screenWidth: screen.width,
+      viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth,
+      url: window.location.href,
+      sessionStorageId: sessionId,
+      ...(libraryType && { libraryType }),
+    })
 
-    return new ArcxAnalyticsSdk(apiKey, identityId, sdkConfig, websocket, libraryUsage)
+    return new ArcxAnalyticsSdk(apiKey, identityId, sdkConfig, websocket, libraryType)
   }
 
   private static async _getIdentitityId(

--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -40,7 +40,10 @@ export class ArcxAnalyticsSdk {
     private _libraryUsage?: LibraryUsageType,
   ) {
     if (_libraryUsage !== 'npm-package') {
-      this.setProvider(window?.ethereum || window.web3?.currentProvider)
+      const provider = window?.ethereum || window.web3?.currentProvider
+      if (provider) {
+        this._trackProvider(provider)
+      }
     }
 
     if (this.sdkConfig.trackPages) {
@@ -393,10 +396,10 @@ export class ArcxAnalyticsSdk {
   }
 
   /**
-   * Sets a new provider. If automatic EVM events tracking is enabled,
+   * Attaches web3 tracking to the given provider. If automatic EVM events tracking is enabled,
    * the registered listeners will be removed from the old provider and added to the new one.
    */
-  setProvider(provider: EIP1193Provider | undefined) {
+  private _trackProvider(provider: EIP1193Provider) {
     if (provider === this._provider) {
       return
     }

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -1,14 +1,16 @@
+/* eslint-disable @typescript-eslint/indent */
 import { ReactNode } from 'react'
-import { EIP1193Provider } from './web3'
 
 export type Attributes = Record<string, unknown>
 export type ChainID = string | number
+
+export const LIBRARY_USAGE_HEADER = 'X-Library-Usage'
+export type LibraryUsageType = 'script-tag' | 'npm-package'
 
 export type SdkConfig = {
   /* ---------------------------- Internal settings --------------------------- */
   cacheIdentity: boolean
   url: string
-  initialProvider?: EIP1193Provider
 
   /* ---------------------------- Tracking options ---------------------------- */
   trackPages: boolean
@@ -22,5 +24,12 @@ export type SdkConfig = {
 export type ArcxAnalyticsProviderProps = {
   apiKey: string
   children?: ReactNode
-  config?: Partial<SdkConfig>
+  config?: Omit<
+    Partial<SdkConfig>,
+    | 'trackWalletConnections'
+    | 'trackChainChanges'
+    | 'trackTransactions'
+    | 'trackSigning'
+    | 'initialProvider'
+  >
 }

--- a/src/utils/createClientSocket.ts
+++ b/src/utils/createClientSocket.ts
@@ -13,9 +13,14 @@ interface IQueryParams {
   sessionStorageId: string
 }
 
-export const createClientSocket = (url: string, queryParams: IQueryParams) => {
+export const createClientSocket = (
+  url: string,
+  queryParams: IQueryParams,
+  headers?: Record<string, string>,
+) => {
   return io(url, {
     query: queryParams,
     transports: ['websocket'],
+    extraHeaders: headers,
   })
 }

--- a/src/utils/createClientSocket.ts
+++ b/src/utils/createClientSocket.ts
@@ -13,14 +13,9 @@ interface IQueryParams {
   sessionStorageId: string
 }
 
-export const createClientSocket = (
-  url: string,
-  queryParams: IQueryParams,
-  headers?: Record<string, string>,
-) => {
+export const createClientSocket = (url: string, queryParams: IQueryParams) => {
   return io(url, {
     query: queryParams,
     transports: ['websocket'],
-    extraHeaders: headers,
   })
 }

--- a/src/utils/postRequest.ts
+++ b/src/utils/postRequest.ts
@@ -6,6 +6,7 @@ export async function postRequest(
   apiKey: string,
   path: string,
   data?: unknown,
+  extraHeaders?: Record<string, string>,
 ): Promise<string> {
   const response = await fetch(`${base}${path}`, {
     method: 'POST',
@@ -13,6 +14,7 @@ export async function postRequest(
       'Content-Type': 'application/json; charset=UTF-8',
       'x-api-key': apiKey,
       'x-sdk-version': SDK_VERSION,
+      ...extraHeaders,
     },
     body: JSON.stringify(data),
   })

--- a/test/ArcxAnalyticsProvider.test.tsx
+++ b/test/ArcxAnalyticsProvider.test.tsx
@@ -6,6 +6,7 @@ import {
   ArcxAnalyticsContext,
   SdkConfig,
   useArcxAnalytics,
+  LIBRARY_USAGE_HEADER,
 } from '../src'
 import { expect } from 'chai'
 import sinon from 'sinon'
@@ -26,32 +27,6 @@ const TRACK_PAGES_CONFIG: SdkConfig = {
   cacheIdentity: false,
 }
 const CUSTOM_EVENT_NAME = 'test-event'
-
-const TestProvider = ({
-  children,
-  providerOverrides,
-}: {
-  children?: React.ReactNode
-  providerOverrides?: Partial<ArcxAnalyticsProviderProps>
-}) => (
-  <ArcxAnalyticsProvider apiKey={TEST_API_KEY} config={TRACK_PAGES_CONFIG} {...providerOverrides}>
-    <ArcxAnalyticsContext.Consumer>
-      {(sdk) => (
-        <div>
-          <div>Identity: {sdk?.identityId}</div>
-          <div
-            id="id-for-click"
-            data-testid="track-click"
-            className="test-classname-1 test-classname-2"
-          >
-            Text to click
-          </div>
-          <div>{children}</div>
-        </div>
-      )}
-    </ArcxAnalyticsContext.Consumer>
-  </ArcxAnalyticsProvider>
-)
 
 const ChildTest = () => {
   const sdk = useArcxAnalytics()
@@ -101,11 +76,46 @@ describe('(int) ArcxAnalyticxProvider', () => {
     cleanup()
   })
 
+  const TestProvider = ({
+    children,
+    providerOverrides,
+  }: {
+    children?: React.ReactNode
+    providerOverrides?: Partial<ArcxAnalyticsProviderProps>
+  }) => (
+    <ArcxAnalyticsProvider apiKey={TEST_API_KEY} config={TRACK_PAGES_CONFIG} {...providerOverrides}>
+      <ArcxAnalyticsContext.Consumer>
+        {(sdk) => (
+          <div>
+            <div>Identity: {sdk?.identityId}</div>
+            <div
+              id="id-for-click"
+              data-testid="track-click"
+              className="test-classname-1 test-classname-2"
+            >
+              Text to click
+            </div>
+            <div>{children}</div>
+          </div>
+        )}
+      </ArcxAnalyticsContext.Consumer>
+    </ArcxAnalyticsProvider>
+  )
+
   describe('Initialization', () => {
-    it('initializes the SDK', async () => {
+    it('initializes the SDK with the library usage type set to "npm-package"', async () => {
       const screen = render(<TestProvider />)
 
-      expect(postRequestStub.calledOnceWith(DEFAULT_SDK_CONFIG.url, TEST_API_KEY, '/identify'))
+      expect(postRequestStub.calledOnce).to.be.true
+      const args = postRequestStub.getCall(0).args
+      expect(args).to.deep.eq([
+        DEFAULT_SDK_CONFIG.url,
+        TEST_API_KEY,
+        '/identify',
+        {
+          [LIBRARY_USAGE_HEADER]: 'npm-package',
+        },
+      ])
       expect(await screen.findByText(`Identity: ${TEST_IDENTITY}`)).to.exist
     })
 

--- a/test/ArcxAnalyticsSdk.test.ts
+++ b/test/ArcxAnalyticsSdk.test.ts
@@ -1,6 +1,6 @@
 import sinon from 'sinon'
 import { expect } from 'chai'
-import { ArcxAnalyticsSdk, LIBRARY_USAGE_HEADER, SdkConfig } from '../src'
+import { ArcxAnalyticsSdk, EIP1193Provider, LIBRARY_USAGE_HEADER, SdkConfig } from '../src'
 import {
   CURRENT_URL_KEY,
   DEFAULT_SDK_CONFIG,
@@ -565,15 +565,7 @@ describe('(unit) ArcxAnalyticsSdk', () => {
         })
       })
 
-      describe('#setProvider', () => {
-        it('deletes currentChainId and currentConnectedAccount if setting to undefined', () => {
-          sdk['currentChainId'] = TEST_CHAIN_ID
-          sdk['currentConnectedAccount'] = TEST_ACCOUNT
-          sdk['setProvider'](undefined)
-          expect(sdk['currentChainId']).to.be.undefined
-          expect(sdk['currentConnectedAccount']).to.be.undefined
-        })
-
+      describe('#_trackProvider', () => {
         describe('setting a provider', () => {
           it('saves the original `request` to _originalRequest', async () => {
             const provider = new MockEthereum()
@@ -583,7 +575,7 @@ describe('(unit) ArcxAnalyticsSdk', () => {
 
             expect(sdk['_originalRequest']).to.be.undefined
 
-            sdk['setProvider'](provider)
+            sdk['_trackProvider'](provider)
 
             expect(sdk['_originalRequest']).to.eq(originalRequest)
           })
@@ -591,11 +583,8 @@ describe('(unit) ArcxAnalyticsSdk', () => {
           it('sets `provider` to the given provider', () => {
             expect(sdk.provider).to.eq(window.ethereum)
 
-            sdk['setProvider'](undefined)
-            expect(sdk.provider).to.be.undefined
-
             const newProvider = new MockEthereum()
-            sdk['setProvider'](newProvider)
+            sdk['_trackProvider'](newProvider)
             expect(sdk.provider).to.eq(newProvider)
           })
 
@@ -609,7 +598,7 @@ describe('(unit) ArcxAnalyticsSdk', () => {
 
             expect(sdk['sdkConfig'].trackTransactions).to.be.true
 
-            sdk['setProvider'](new MockEthereum())
+            sdk['_trackProvider'](new MockEthereum())
             expect(registerAccountsChangedStub).to.be.called
           })
 
@@ -620,7 +609,7 @@ describe('(unit) ArcxAnalyticsSdk', () => {
 
             expect(sdk['sdkConfig'].trackChainChanges).to.be.true
 
-            sdk['setProvider'](new MockEthereum())
+            sdk['_trackProvider'](new MockEthereum())
             expect(registerChainChangedStub).to.be.called
           })
 
@@ -631,7 +620,7 @@ describe('(unit) ArcxAnalyticsSdk', () => {
 
             expect(sdk['sdkConfig'].trackSigning).to.be.true
 
-            sdk['setProvider'](new MockEthereum())
+            sdk['_trackProvider'](new MockEthereum())
             expect(trackSigningStub).to.be.called
           })
 
@@ -642,7 +631,7 @@ describe('(unit) ArcxAnalyticsSdk', () => {
 
             expect(sdk['sdkConfig'].trackTransactions).to.be.true
 
-            sdk['setProvider'](new MockEthereum())
+            sdk['_trackProvider'](new MockEthereum())
             expect(trackTransactionsStub).to.be.called
           })
         })
@@ -657,7 +646,7 @@ describe('(unit) ArcxAnalyticsSdk', () => {
             expect(window.ethereum.request).to.not.eq(originalRequest)
 
             const newProvider = new MockEthereum()
-            sdk['setProvider'](newProvider)
+            sdk['_trackProvider'](newProvider)
 
             expect(window.ethereum.request).to.eq(originalRequest)
           })
@@ -671,7 +660,7 @@ describe('(unit) ArcxAnalyticsSdk', () => {
             expect(window.ethereum.request).to.not.eq(originalRequest)
 
             const newProvider = new MockEthereum()
-            sdk['setProvider'](newProvider)
+            sdk['_trackProvider'](newProvider)
 
             expect(window.ethereum.request).to.eq(originalRequest)
           })
@@ -686,7 +675,11 @@ describe('(unit) ArcxAnalyticsSdk', () => {
             )
             expect((window.ethereum as any as EventEmitter).listenerCount('chainChanged')).to.eq(1)
 
-            sdk['setProvider'](undefined)
+            sdk['_trackProvider']({
+              on: sinon.stub(),
+              removeListener: sinon.stub(),
+              request: sinon.stub(),
+            } as EIP1193Provider)
 
             expect((window.ethereum as any as EventEmitter).listenerCount('accountsChanged')).to.eq(
               0,

--- a/test/ArcxAnalyticsSdk.test.ts
+++ b/test/ArcxAnalyticsSdk.test.ts
@@ -92,9 +92,9 @@ describe('(unit) ArcxAnalyticsSdk', () => {
       })
     })
 
-    it('sets _libraryUsage if it is passed', async () => {
+    it('sets _libraryType if it is passed', async () => {
       const sdk = await ArcxAnalyticsSdk.init('', ALL_FALSE_CONFIG, 'npm-package')
-      expect(sdk['_libraryUsage']).to.equal('npm-package')
+      expect(sdk['_libraryType']).to.equal('npm-package')
     })
 
     it('makes an /identity call when no identity is found in localStorage', async () => {
@@ -195,23 +195,18 @@ describe('(unit) ArcxAnalyticsSdk', () => {
       expect(sessionId).to.not.be.null
 
       expect(sdk['socket']).to.be.eq(socketStub)
-      expect(createClientSocketStub).to.be.calledOnceWith(
-        DEFAULT_SDK_CONFIG.url,
-        {
-          apiKey: TEST_API_KEY,
-          identityId: TEST_IDENTITY,
-          sdkVersion: SDK_VERSION,
-          screenHeight: TEST_SCREEN.height,
-          screenWidth: TEST_SCREEN.width,
-          viewportHeight: TEST_VIEWPORT.height,
-          viewportWidth: TEST_VIEWPORT.width,
-          url: TEST_JSDOM_URL,
-          sessionStorageId: sessionId,
-        },
-        {
-          [LIBRARY_USAGE_HEADER]: 'script-tag',
-        },
-      )
+      expect(createClientSocketStub).to.be.calledOnceWith(DEFAULT_SDK_CONFIG.url, {
+        apiKey: TEST_API_KEY,
+        identityId: TEST_IDENTITY,
+        sdkVersion: SDK_VERSION,
+        screenHeight: TEST_SCREEN.height,
+        screenWidth: TEST_SCREEN.width,
+        viewportHeight: TEST_VIEWPORT.height,
+        viewportWidth: TEST_VIEWPORT.width,
+        url: TEST_JSDOM_URL,
+        sessionStorageId: sessionId,
+        libraryType: 'script-tag',
+      })
     })
 
     it('creates a websocket instance with the existing session id if one exists', async () => {
@@ -690,9 +685,9 @@ describe('(unit) ArcxAnalyticsSdk', () => {
       })
 
       describe('#_reportError', () => {
-        it('calls postRequest with library usage header if _libraryUsage is set', async () => {
+        it('calls postRequest with library usage header if _libraryType is set', async () => {
           const errorMsg = 'TestError: this should not happen'
-          sdk['_libraryUsage'] = 'script-tag'
+          sdk['_libraryType'] = 'script-tag'
           await sdk['_report']('error', errorMsg)
           expect(postRequestStub).calledOnceWith(
             DEFAULT_SDK_CONFIG.url,

--- a/test/utils/postRequest.test.ts
+++ b/test/utils/postRequest.test.ts
@@ -23,7 +23,11 @@ describe('(unit) postRequest', () => {
         },
       },
     }
-    const res = await postRequest('https://example.com/', TEST_API_KEY, 'v1', data)
+    const extraHeaders = {
+      'x-extra-header': TEST_API_KEY,
+    }
+
+    const res = await postRequest('https://example.com/', TEST_API_KEY, 'v1', data, extraHeaders)
 
     expect(res).to.equal('test response')
     expect(SDK_VERSION).to.not.be.empty
@@ -33,6 +37,7 @@ describe('(unit) postRequest', () => {
         'Content-Type': 'application/json; charset=UTF-8',
         'x-api-key': TEST_API_KEY,
         'x-sdk-version': SDK_VERSION,
+        ...extraHeaders,
       },
       body: JSON.stringify(data),
     })


### PR DESCRIPTION
- disabled automatic web3 event tracking for the npm package
- added the header `X-Library-Usage` to each request depending if the SDK is used with a script tag or npm package
- removed `setProvider()` because dApps supporting more wallets than Metamasks should manually track their web3 events (connect, transact, etc)

Closes #158 
Closes #167 