### PR TITLE
Ignore reporting the library usage on the first page call

### DIFF
--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -107,7 +107,7 @@ export class ArcxAnalyticsSdk {
       sessionStorage.setItem(CURRENT_URL_KEY, window.location.href)
     }
 
-    return this.page()
+    return this.page(true)
   }
 
   private _trackPagesChange() {
@@ -375,13 +375,13 @@ export class ArcxAnalyticsSdk {
   /**
    * Flexible event reporting method to be used internally.
    */
-  private _event(event: Event, attributes?: Attributes) {
+  private _event(event: Event, attributes?: Attributes, ignoreLibraryUsage?: boolean) {
     // If the socket is not connected, the event will be buffered until reconnection and sent then
     this.socket.emit('submit-event', {
       event,
       attributes,
       url: window.location.href,
-      libraryType: getLibraryType(),
+      ...(!ignoreLibraryUsage && { libraryType: getLibraryType() }),
     })
   }
 
@@ -467,10 +467,14 @@ export class ArcxAnalyticsSdk {
   /**
    * Logs the current page
    */
-  page(): void {
-    return this._event(Event.PAGE, {
-      referrer: document.referrer,
-    })
+  page(ignoreLibraryUsage?: boolean): void {
+    return this._event(
+      Event.PAGE,
+      {
+        referrer: document.referrer,
+      },
+      ignoreLibraryUsage,
+    )
   }
 
   /**

--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -107,7 +107,13 @@ export class ArcxAnalyticsSdk {
       sessionStorage.setItem(CURRENT_URL_KEY, window.location.href)
     }
 
-    return this.page(true)
+    return this._event(
+      Event.PAGE,
+      {
+        referrer: document.referrer,
+      },
+      true,
+    )
   }
 
   private _trackPagesChange() {
@@ -467,14 +473,10 @@ export class ArcxAnalyticsSdk {
   /**
    * Logs the current page
    */
-  page(ignoreLibraryUsage?: boolean): void {
-    return this._event(
-      Event.PAGE,
-      {
-        referrer: document.referrer,
-      },
-      ignoreLibraryUsage,
-    )
+  page(): void {
+    return this._event(Event.PAGE, {
+      referrer: document.referrer,
+    })
   }
 
   /**

--- a/test/ArcxAnalyticsSdk.test.ts
+++ b/test/ArcxAnalyticsSdk.test.ts
@@ -95,9 +95,13 @@ describe('(unit) ArcxAnalyticsSdk', () => {
 
       expect(socketStub.emit.firstCall).calledWith(
         'submit-event',
-        getAnalyticsData(Event.PAGE, {
-          referrer: TEST_REFERRER,
-        }),
+        getAnalyticsData(
+          Event.PAGE,
+          {
+            referrer: TEST_REFERRER,
+          },
+          true,
+        ),
       )
     })
 
@@ -256,7 +260,7 @@ describe('(unit) ArcxAnalyticsSdk', () => {
             referrer: TEST_REFERRER,
           }
           sdk.page()
-          expect(eventStub).calledOnceWithExactly(Event.PAGE, attributes)
+          expect(eventStub).calledOnceWithExactly(Event.PAGE, attributes, undefined)
         })
       })
 
@@ -721,9 +725,13 @@ describe('(unit) ArcxAnalyticsSdk', () => {
           sdk['sdkConfig'].trackPages = true
 
           sdk['_trackFirstPageVisit']()
-          expect(eventStub).calledOnceWithExactly(Event.PAGE, {
-            referrer: TEST_REFERRER,
-          })
+          expect(eventStub).calledOnceWithExactly(
+            Event.PAGE,
+            {
+              referrer: TEST_REFERRER,
+            },
+            true,
+          )
 
           sdk['sdkConfig'].trackPages = false
         })
@@ -732,9 +740,13 @@ describe('(unit) ArcxAnalyticsSdk', () => {
           sdk['sdkConfig'].trackPages = true
 
           sdk['_trackFirstPageVisit']()
-          expect(eventStub).calledOnceWithExactly(Event.PAGE, {
-            referrer: TEST_REFERRER,
-          })
+          expect(eventStub).calledOnceWithExactly(
+            Event.PAGE,
+            {
+              referrer: TEST_REFERRER,
+            },
+            true,
+          )
 
           sdk['sdkConfig'].trackPages = false
         })
@@ -1120,12 +1132,12 @@ describe('(unit) ArcxAnalyticsSdk', () => {
     })
   })
 
-  function getAnalyticsData(event: Event, attributes: any) {
+  function getAnalyticsData(event: Event, attributes: any, ignoreLibraryUsage?: boolean) {
     return {
       event,
       attributes,
       url: TEST_JSDOM_URL,
-      libraryType: 'npm-package',
+      ...(!ignoreLibraryUsage && { libraryType: 'npm-package' }),
     }
   }
 })

--- a/test/ArcxAnalyticsSdk.test.ts
+++ b/test/ArcxAnalyticsSdk.test.ts
@@ -260,7 +260,7 @@ describe('(unit) ArcxAnalyticsSdk', () => {
             referrer: TEST_REFERRER,
           }
           sdk.page()
-          expect(eventStub).calledOnceWithExactly(Event.PAGE, attributes, undefined)
+          expect(eventStub).calledOnceWithExactly(Event.PAGE, attributes)
         })
       })
 


### PR DESCRIPTION
The first PAGE call is fired before `window.arcx` is set, so had to accomodate for that.
