### PR TITLE
Do not throw inside `request()`

### DIFF
--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -270,9 +270,7 @@ export class ArcxAnalyticsSdk {
         }
 
         if (!this.currentChainId) {
-          this._reportErrorAndThrow(
-            'ArcxAnalyticsSdk::_trackTransactions: currentChainId is not set',
-          )
+          this._report('error', 'ArcxAnalyticsSdk::_trackTransactions: currentChainId is not set')
         }
 
         this._event(Event.TRANSACTION_TRIGGERED, {


### PR DESCRIPTION
We should never throw inside the `request()` function because this can prevent clients from executing transactions. Even though it is a valid error, we should just log it and continue - never throw.
