### PR TITLE
Request connected account in chain changed if no account was previously recorded

### DIFF
--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -224,6 +224,7 @@ export class ArcxAnalyticsSdk {
       } catch (err) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         if ((err as any).code !== 4001) {
+          // 4001: The request is rejected by the user , see https://docs.metamask.io/wallet/reference/provider-api/#errors
           this._report(
             'error',
             `ArcxAnalyticsSdk::_onChainChanged: unable to get account. eth_requestAccounts threw an error`,

--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -1,9 +1,11 @@
+import EventEmitter from 'events'
+
 export interface RequestArguments {
   method: string
   params?: unknown[] | Record<string, unknown>
 }
 
-export interface EIP1193Provider {
+export interface EIP1193Provider extends EventEmitter {
   request<T>(args: RequestArguments): Promise<T | null | undefined>
   on(eventName: string | symbol, listener: (...args: unknown[]) => void): this
   removeListener(eventName: string | symbol, listener: (...args: unknown[]) => void): this


### PR DESCRIPTION
Closes https://github.com/arcxmoney/sdk-api/issues/471

If no account was recorded, request `eth_requestAccounts` to get the connected account from the provider.

- [x] Test new build locally
