### PR TITLE
Fix automatic disconnect events

### DIFF
--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -173,7 +173,7 @@ export class ArcxAnalyticsSdk {
   }
 
   private _handleAccountDisconnected() {
-    if (!this.currentChainId && !this.currentConnectedAccount) {
+    if (!this.currentConnectedAccount) {
       /**
        * It is possible that this function has already been called once and the cached values
        * have been cleared. This can happen in the following scenario:
@@ -189,7 +189,7 @@ export class ArcxAnalyticsSdk {
 
     const disconnectAttributes = {
       account: this.currentConnectedAccount,
-      chain: this.currentChainId,
+      chainId: this.currentChainId,
     }
     this.currentChainId = undefined
     this.currentConnectedAccount = undefined

--- a/test/ArcxAnalyticsSdk.test.ts
+++ b/test/ArcxAnalyticsSdk.test.ts
@@ -1297,6 +1297,33 @@ describe('(unit) ArcxAnalyticsSdk', () => {
           expect(provider.listenerCount('chainChanged')).to.eq(1)
         })
       })
+
+      describe('#_handleAccountDisconnected', () => {
+        it('does not call _event if currentChainId or currentConnectedAccount are undefined', async () => {
+          const eventStub = sinon.stub(sdk, '_event' as any)
+          sdk.currentConnectedAccount = undefined
+          await sdk['_handleAccountDisconnected']()
+          expect(eventStub).to.not.have.been.called
+
+          sdk.currentConnectedAccount = TEST_ACCOUNT
+          sdk.currentChainId = undefined
+          await sdk['_handleAccountDisconnected']()
+          expect(eventStub).to.have.been.called
+        })
+
+        it('calls _event with chainId and account and sets currentChainId and currentConnectedAccount to undefined', async () => {
+          const eventStub = sinon.stub(sdk, '_event' as any)
+          sdk.currentConnectedAccount = TEST_ACCOUNT
+          sdk.currentChainId = TEST_CHAIN_ID
+          await sdk['_handleAccountDisconnected']()
+          expect(eventStub).calledOnceWithExactly(Event.DISCONNECT, {
+            chainId: TEST_CHAIN_ID,
+            account: TEST_ACCOUNT,
+          })
+          expect(sdk.currentConnectedAccount).to.be.undefined
+          expect(sdk.currentChainId).to.be.undefined
+        })
+      })
     })
   })
 


### PR DESCRIPTION
Do not fire a `DISCONNECT` event if `currentConnectedAccount` is undefined and emit `chainId`
instead of `chain`.

closes #179
