### PR TITLE
Add `disabled` prop to the SDK provider

### DIFF
--- a/src/ArcxAnalyticsProvider.tsx
+++ b/src/ArcxAnalyticsProvider.tsx
@@ -4,7 +4,12 @@ import { ArcxAnalyticsProviderProps } from './types'
 
 export const ArcxAnalyticsContext = createContext<ArcxAnalyticsSdk | undefined>(undefined)
 
-export const ArcxAnalyticsProvider = ({ apiKey, config, children }: ArcxAnalyticsProviderProps) => {
+export const ArcxAnalyticsProvider = ({
+  apiKey,
+  config,
+  disabled,
+  children,
+}: ArcxAnalyticsProviderProps) => {
   const [sdk, setSdk] = useState<ArcxAnalyticsSdk | undefined>()
   const initializedStartedRef = useRef(false)
 
@@ -12,6 +17,8 @@ export const ArcxAnalyticsProvider = ({ apiKey, config, children }: ArcxAnalytic
     if (!apiKey) {
       throw new Error('ArcxAnalyticxProvider: No API key provided')
     }
+    if (disabled) return
+
     if (initializedStartedRef.current) return
     initializedStartedRef.current = true
 
@@ -22,7 +29,7 @@ export const ArcxAnalyticsProvider = ({ apiKey, config, children }: ArcxAnalytic
       trackTransactions: false,
       trackSigning: false,
     }).then((sdk) => setSdk(sdk))
-  }, [apiKey])
+  }, [apiKey, disabled])
 
   return <ArcxAnalyticsContext.Provider value={sdk}>{children}</ArcxAnalyticsContext.Provider>
 }

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -14,4 +14,4 @@ export const DEFAULT_SDK_CONFIG: SdkConfig = {
 export const IDENTITY_KEY = 'identity'
 export const SESSION_STORAGE_ID_KEY = 'arcx-session-id'
 export const CURRENT_URL_KEY = 'arcx-analytics-current-url'
-export const SDK_VERSION = 'local'
+export const SDK_VERSION = '2.0.0'

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -14,4 +14,4 @@ export const DEFAULT_SDK_CONFIG: SdkConfig = {
 export const IDENTITY_KEY = 'identity'
 export const SESSION_STORAGE_ID_KEY = 'arcx-session-id'
 export const CURRENT_URL_KEY = 'arcx-analytics-current-url'
-export const SDK_VERSION = '2.0.0'
+export const SDK_VERSION = 'local'

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -24,6 +24,11 @@ export type SdkConfig = {
 export type ArcxAnalyticsProviderProps = {
   apiKey: string
   children?: ReactNode
+  /**
+   * If you want to disable analytics for a specific environment, you can do so by setting this prop
+   * to true.
+   */
+  disabled?: boolean
   config?: Omit<
     Partial<SdkConfig>,
     | 'trackWalletConnections'

--- a/test/ArcxAnalyticsProvider.test.tsx
+++ b/test/ArcxAnalyticsProvider.test.tsx
@@ -119,6 +119,11 @@ describe('(int) ArcxAnalyticxProvider', () => {
       expect(postRequestStub.called).to.be.false
     })
 
+    it('does not initialize if disabled is true', async () => {
+      render(<TestProvider providerOverrides={{ disabled: true }} />)
+      expect(postRequestStub.called).to.be.false
+    })
+
     describe('#trackClicks', () => {
       let screen: RenderResult
 


### PR DESCRIPTION
This is the result of a user request to allow them to skip initialization for non-production environments.
