### PR TITLE
Update constants to match new domain 🌐 

### DIFF
--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -8,10 +8,10 @@ export const DEFAULT_SDK_CONFIG: SdkConfig = {
   trackTransactions: true,
   trackSigning: true,
   trackClicks: true,
-  url: 'https://prod.analytics.api.arcx.money/v1',
+  url: 'https://prod.clickstream.api.0xarc.io/v1',
 }
 
-export const IDENTITY_KEY = 'identity'
-export const SESSION_STORAGE_ID_KEY = 'arcx-session-id'
-export const CURRENT_URL_KEY = 'arcx-analytics-current-url'
+export const IDENTITY_KEY = '0xArc-identity'
+export const SESSION_STORAGE_ID_KEY = '0xArc-session-id'
+export const CURRENT_URL_KEY = '0xArc-analytics-current-url'
 export const SDK_VERSION = 'local'


### PR DESCRIPTION
As per incoming changes happening in backend, we should update constants so we can start deprecating the old domain.

CNAMEs will be added accordingly before deployment.

Blocked until https://github.com/arcxmoney/sdk-api/pull/530 is deployed.

Notes: Will updating the constants of browser cache keys have any adverse side effects @gtupak ? 🤔 Thinking if it will reset identities by creating new ones (and is that a big deal?).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated configuration keys with a new prefix for improved consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->