### PR TITLE
Fix: Revert URL until SSL certs are provisioned.

### DIFF
--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -8,7 +8,9 @@ export const DEFAULT_SDK_CONFIG: SdkConfig = {
   trackTransactions: true,
   trackSigning: true,
   trackClicks: true,
-  url: 'https://prod.clickstream.api.0xarc.io/v1',
+  // TODO: Add back in once GCP Certificates are fixed (potentially linked to CrowdStrike)
+  // url: 'https://prod.clickstream.api.0xarc.io/v1',
+  url: 'https://prod.analytics.api.arcx.money/v1',
 }
 
 export const IDENTITY_KEY = '0xArc-identity'


### PR DESCRIPTION
As we are still waiting for Google SSL certs to be provisioned on our Load Balancers, let's revert to previous url to be safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the SDK configuration to use a new URL for the Analytics API, enhancing the application's connectivity and reliability.
  
- **Bug Fixes**
	- Addressed issues with the previous Clickstream API endpoint by temporarily removing it and providing a functional alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->