### PR TITLE
Remove manual npm publish scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,6 @@
   },
   "scripts": {
     "prebuild": "yarn clean",
-    "publish-patch": "npm version patch && npm publish",
-    "publish-minor": "npm version minor && npm publish",
     "build": "yarn build-cjs && yarn build-esm && yarn webpack --mode=production",
     "build-cjs": "yarn tsc --build",
     "build-esm": "yarn tsc -m es6 --outdir dist/esm",


### PR DESCRIPTION
All releases should be made with the manual GitHub workflow. To avoid confusion in the future, I am removing the manual npm publish scripts from `package.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined our release automation by removing older workflows for versioning and publishing minor or patch updates. All other build, testing, and maintenance routines continue to operate as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->